### PR TITLE
allways update packages indexes

### DIFF
--- a/tasks/10_checks-repos.yml
+++ b/tasks/10_checks-repos.yml
@@ -113,8 +113,5 @@
   apt:
     update_cache: yes
     cache_valid_time: 0
-  when: > 
-      alternc_repo_add is changed or 
-      ( alternc_debian_repo_sid_add is defined and alternc_debian_repo_sid_add is changed )
 
 ...


### PR DESCRIPTION
I propose these changes to resolve [these](https://github.com/UdelaRInterior/ansible-AlternC/pull/8#discussion_r643520888) conversation. To ensure there will be no 404 errors and install the latest version of the packages.