### PR TITLE
Solving #12 with a login into AlternC panel

### DIFF
--- a/defaults/main/70_alternc-custom.yml
+++ b/defaults/main/70_alternc-custom.yml
@@ -34,15 +34,18 @@ alternc_image_url_path: /images
 alternc_local_file_path: '{{ playbook_dir }}/host_vars/{{ inventory_hostname }}/files'
 
 ## The logo for the authentcation page of AlternC panel
-## Should be horizontal, rectangle. When unefined or empty string, no custom logo is set
+# Should be an horizontal, rectangle image. The filename must not include any subfolder. 
+# When unefined or empty string, no custom logo is set
 # alternc_logo_login: my_logo.png 
 
-# The logo in the top of the menu of AlternC panel
-# Should be a square image
+## The filename of the logo in the top of the menu of AlternC panel
+# Should be a square image and the filename must not include any subfolder. 
+# When unefined or empty string, no custom logo is set
 alternc_logo_menu: '{{ alternc_logo_login | default( "" ) }}' 
 
-# The favicon of the panel's pages
+## The favicon of the panel's pages
 # Should be a square image. Can be the .ico file itself, or a .png from which the role builds it. 
+# The filename must not include any subfolder. When unefined or empty string, no custom favicon is set
 alternc_favicon: '{{ alternc_logo_menu | default( "" ) }}'
 
 # Alternativley to previous three variables, you can directly populate the following structure

--- a/defaults/main/70_alternc-custom.yml
+++ b/defaults/main/70_alternc-custom.yml
@@ -23,6 +23,10 @@
 #     alternc_config_variables structure, defined in /defaults/main/30_alternc_opan
 
 ## Variables to build and manage AlternC logos
+# Bewere of this issue: https://github.com/UdelaRInterior/ansible-AlternC/issues/12
+# for some buggy reason that our hook [here](tasaks/90_alternc-custom.yml#L21) didn't solve, the logoss tasks
+# have to be ran twice. you can do it with `alternc_custom` tag:
+#  ansible-playbook alternc-playbook.yml --tags alternc_custom
 
 # The folder of AlternC panel images an logos (should not be changed)
 alternc_image_file_path: /usr/share/alternc/panel/admin/images
@@ -71,12 +75,14 @@ alternc_logos:
   - 64x64
   - 128x128
 
-## Name of package that provide `icotools` command on ansible controller, needed if the role builds the .ico file,
-# Remark: default value is at least for common Debian-like distributions. If your local distro has another 
+## Name of package that provides `icotools` command on ansible controller, needed if the role builds the .ico file,
+# Remark: default value is at least ok for common Debian-like distributions. If your local distro has another 
 # name for this package, there is no much sense to store this value in a git repo. As it's needed only once for
 # package install, it makes more sense to set it in the command line: 
 #  ansible-playbook alternc-playbook.yml --extra-vars '{"alternc_icoutils_pkg":"icoutils-custom"}'  
-# You can also install manually any package providing `icotool` command line before running the role
+# You can also install manually any package providing `icotool` command line before running the role 
+# and skip `icoutils` tag: 
+#  ansible-playbook alternc-playbook.yml --skip-tags icoutils
 alternc_icoutils_pkg: "icoutils"
 
 ...

--- a/tasks/10_checks-repos.yml
+++ b/tasks/10_checks-repos.yml
@@ -75,7 +75,8 @@
     vars: 
       alternc_check_icoutils_pckg: 'ansible_facts.packages.{{ alternc_icoutils_pkg }}'
 
-  when: alternc_favicon is string and alternc_favicon != '' 
+  when: alternc_favicon is string and alternc_favicon != ''
+  tags: icoutils
 
 - debug: 
     msg: "{{ ansible_distribution }}-{{ ansible_distribution_release }}.yml"

--- a/tasks/20_debconf.yml
+++ b/tasks/20_debconf.yml
@@ -4,13 +4,11 @@
 
 - name: Install "debconf" and "debconf-utils"
   apt:
-    name: "{{ alternc_debconf_pacakages }}"
-    cache_valid_time: 3600
-    state: latest
-  vars:
-    alternc_debconf_pacakages:
+    name:
     - debconf
     - debconf-utils
+    cache_valid_time: 3600
+    state: latest
 
 - name: Fix debconf options for alternc and phpmyadmin
   debconf:

--- a/tasks/90_alternc-custom.yml
+++ b/tasks/90_alternc-custom.yml
@@ -18,7 +18,7 @@
 
 ## As empirically detected in https://github.com/UdelaRInterior/ansible-AlternC/issues/12
 ## AlternC needs a first admin login into panel for the AlternC variables set to be efective. 
-- name: admin web access to AlternC panel just installed
+- name: "Hook: admin web access to AlternC panel just installed"
   uri:
     url: '{{ alternc_desktop_protocol }}://{{ alternc_debconf_desktopname }}/login.php'
     method: POST
@@ -79,7 +79,7 @@
       Cookie: "{{ alternc_panel_login_invalid_certs.set_cookie }}"
   register: alternc_panel_logout_invalid_certs
   when: 
-  - alternc_panel_login_invalid_certs is defined
+  - alternc_panel_login_invalid_certs is not skipped
   - alternc_panel_login_invalid_certs is succeeded
 
 

--- a/tasks/90_alternc-custom.yml
+++ b/tasks/90_alternc-custom.yml
@@ -16,6 +16,72 @@
 #   comment: 'You can specify a logo for the menu, example /images/my_logo.png .'
 # (...)
 
+## As empirically detected in https://github.com/UdelaRInterior/ansible-AlternC/issues/12
+## AlternC needs a first admin login into panel for the AlternC variables set to be efective. 
+- name: admin web access to AlternC panel just installed
+  uri:
+    url: '{{ alternc_desktop_protocol }}://{{ alternc_debconf_desktopname }}/login.php'
+    method: POST
+    body_format: form-urlencoded
+    body: 
+      username: admin
+      password: '{{ alternc_admin_pass }}'
+  register: alternc_panel_login
+  become: no
+  delegate_to: localhost
+  ignore_errors: yes
+
+- name: Optional stop if invalid certificates
+  pause:
+    prompt: >
+      LetsEncrypt certificate of AlternC panel were not (yet?) generated. It may happend after, but on
+      some plateforms (such as a Proxmox LXC container with buster) SSL certificate auto-provision is broken.
+  when:
+  - alternc_panel_login is failed
+  - alternc_panel_login.msg | regex_search( 'CERTIFICATE_VERIFY_FAILED')  
+
+- name: Logout form AlternC panel when succeed
+  uri:
+    url: '{{ alternc_desktop_protocol }}://{{ alternc_debconf_desktopname }}/mem_logout.php'
+    method: GET
+    return_content: yes
+    headers:
+      Cookie: "{{ alternc_panel_login.set_cookie }}"
+  register: alternc_panel_logout
+  become: no
+  delegate_to: localhost
+  when: alternc_panel_login is succeeded
+
+- name: admin web access to AlternC panel just installed, accepting invalid certs
+  uri:
+    url: '{{ alternc_desktop_protocol }}://{{ alternc_debconf_desktopname }}/login.php'
+    method: POST
+    validate_certs: no
+    body_format: form-urlencoded
+    body: 
+      username: admin
+      password: '{{ alternc_admin_pass }}'
+  register: alternc_panel_login_invalid_certs
+  become: no
+  delegate_to: localhost
+  when: alternc_panel_login is failed
+
+- debug:
+    var: alternc_panel_login_invalid_certs
+    verbosity: 2
+
+- name: Logout form AlternC panel when succeed with invalid certs
+  uri:
+    url: '{{ alternc_desktop_protocol }}://{{ alternc_debconf_desktopname }}/mem_logout.php'
+    method: GET
+    validate_certs: no
+    headers:
+      Cookie: "{{ alternc_panel_login_invalid_certs.set_cookie }}"
+  register: alternc_panel_logout_invalid_certs
+  when: 
+  - alternc_panel_login_invalid_certs is defined
+  - alternc_panel_login_invalid_certs is succeeded
+
 
 - name: Build, upload and configure AlternC panel's logos
   include_tasks: include/alternc-logos.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -35,5 +35,6 @@
 - import_tasks: 80_alternc-slavedns.yml
 
 - import_tasks: 90_alternc-custom.yml
+  tags: alternc_custom
 
 ...


### PR DESCRIPTION
As you requested, @vamgnu , to have individual reviews, here's a piece of code that adds, with ansible module `uri`, a login and logout into AlternC web panel, in order to solve #12 .

By the way, this codes adds a check of SSL certificate generation, which is not always working. 

A few lines of documentation of logo's variables felt here (because i forgot to "save" before commiting). 