### PR TITLE
optional installation of phpmyadmin from backports or sid

### DIFF
--- a/defaults/main/05_packages.yml
+++ b/defaults/main/05_packages.yml
@@ -15,8 +15,16 @@
 # If this optional variable is set, it overrrides the default php version by distribution in vars/ files
 # alternc_php_version: '7.3'
 
+## Flag defining for buster if we take phpmyadmin from backports or form Sid
+# For buster, if `alternc_phpmyadmin_backport` we install backports phpmyadmin, if not from Sid
+alternc_debian_backport: yes
+
+# Custom debian buster backports repositories
+alternc_debian_backport_repo: http://ftp.debian.org/debian/
+alternc_debian_backport_branch: buster-backports main contrib
+
 # Custom debian sid repo for phpmyadmin when we install AlternC in buster 
-alternc_debian_sid_repo: http://ftp.debian.org/debian/
+alternc_debian_sid_repo: '{{ alternc_debian_backport_repo }}'
 alternc_debian_sid_branch: sid main
 
 ...

--- a/tasks/10_checks-repos.yml
+++ b/tasks/10_checks-repos.yml
@@ -98,18 +98,31 @@
   register: alternc_repo_add
 
 - block: 
-  - name: Define stable as preferred debian distribution
-    lineinfile: 
-      path: /etc/apt/apt.conf.d/30StableRelease
-      line: 'APT::Default-Release "stable";'
-      create: yes
-      state: present
 
-  - name: If distribution is buster, add Sid repository for phpmyadmin
+  - name: If distribution is buster and alternc_debian_backport, add backports repository for phpmyadmin
     apt_repository: 
-      repo: "deb {{ alternc_debian_sid_repo }} {{ alternc_debian_sid_branch }}"
+      repo: "deb {{ alternc_debian_backport_repo }} {{ alternc_debian_backport_branch }}"
       state: present
-    register: debian_repo_sid_add
+    register: debian_repo_backport_add
+    when: alternc_debian_backport
+
+  - block: 
+
+    - name: Define stable as preferred debian distribution
+      lineinfile: 
+        path: /etc/apt/apt.conf.d/30StableRelease
+        line: 'APT::Default-Release "stable";'
+        create: yes
+        state: present
+
+    - name: If distribution is buster and not alternc_debian_backport, add Sid repository for phpmyadmin
+      apt_repository: 
+        repo: "deb {{ alternc_debian_sid_repo }} {{ alternc_debian_sid_branch }}"
+        state: present
+      register: debian_repo_sid_add
+    
+    when: not alternc_debian_backport
+
   when: ( ansible_distribution == 'Debian') and (ansible_distribution_release == 'buster')
   
 - name: Update packages indexes
@@ -118,6 +131,7 @@
     cache_valid_time: 0
   when: > 
       alternc_repo_add is changed or 
+      ( debian_repo_backport_add is defined and debian_repo_backport_add is changed ) or 
       ( alternc_debian_repo_sid_add is defined and alternc_debian_repo_sid_add is changed )
 
 ...

--- a/tasks/30_packages.yml
+++ b/tasks/30_packages.yml
@@ -31,6 +31,15 @@
 #    cache_valid_time: 3600
 #  when: ansible_distribution_release == "buster"
 
+- name: Install or update phpmyadmin backports dist dependencies 
+  apt:
+    name: 
+    - php-twig 
+    state: latest
+    default_release: buster-backports
+    cache_valid_time: 3600
+  when: ansible_distribution_release == "buster" and alternc_debian_backport
+
 - name: Install or update phpmyadmin Sid dist dependencies 
   apt:
     name: 
@@ -45,7 +54,7 @@
     default_release: sid
     state: latest
     cache_valid_time: 3600
-  when: ansible_distribution_release == "buster"
+  when: ansible_distribution_release == "buster" and not alternc_debian_backport
 
 ### These packages are ok by dependencies in stable. 
 ## remove these comments in a future version


### PR DESCRIPTION
Followin issue #17, the commit d6bda25  I'm submitting here works for first installation of AlternC with `phpmyadmin` either form buster-backports (default) or Sid dists. 

However, it's not idempotent, in the sense that, if you installed from Sid, changing the flag and running the role doesn't downgrade to backports, and the reverse "upgrade" is only partial. But it's a first acceptable solution, one can manually tweak the installation if needed.