### PR TITLE
Solving #19: full configuration of DNS slave IPs authorization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Solves issue #15 (but `https_force` variable has no effet on AlternC panel, which is always in https)
 * parially solves #12, and gives a workaround running playbook a second time with tag `alternc_custom`
-* solves wssie 19 with a workaround: a flag to set or not DNS allowed slave IPs, to solve idempotency
+* solves issue 19 with a workaround: a flag to set or not DNS allowed slave IPs, to solve idempotency
 * a [branch `web_api`](https://github.com/UdelaRInterior/ansible-AlternC/tree/web_api) is let to explore
   further the scrapping of AlternC web interface, wich may solve better previous issues, but we let them there, because they are minor.
 * this version should be considered as completed for AlternC installation in buster, along with alternc-slavedns instances, at least up to AlternC 3.5 release.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change log of [ansible role AlternC](https://github.com/UdelaRInterior/ansible-AlternC)
 
+## [v3.2.0-rc1](https://github.com/UdelaRInterior/ansible-AlternC/releases/tag/v3.2.0-rc1)
+
+* Solves issue #15 (but `https_force` variable has no effet on AlternC panel, which is always in https)
+* parially solves #12, and gives a workaround running playbook a second time with tag `alternc_custom`
+* solves wssie 19 with a workaround: a flag to set or not DNS allowed slave IPs, to solve idempotency
+* a [branch `web_api`](https://github.com/UdelaRInterior/ansible-AlternC/tree/web_api) is let to explore
+  further the scrapping of AlternC web interface, wich may solve better previous issues, but we let them there, because they are minor.
+* this version should be considered as completed for AlternC installation in buster, along with alternc-slavedns instances, at least up to AlternC 3.5 release.  
+
 ## [v3.1.1](https://github.com/UdelaRInterior/ansible-AlternC/releases/tag/v3.1.1)
 
 * Simplify reducing unneeded dependencies or packages

--- a/defaults/main/05_packages.yml
+++ b/defaults/main/05_packages.yml
@@ -15,8 +15,16 @@
 # If this optional variable is set, it overrrides the default php version by distribution in vars/ files
 # alternc_php_version: '7.3'
 
+## Flag defining for buster if we take phpmyadmin from backports or form Sid
+# For buster, if `alternc_phpmyadmin_backport` we install backports phpmyadmin, if not from Sid
+alternc_debian_backport: yes
+
+# Custom debian buster backports repositories
+alternc_debian_backport_repo: http://ftp.debian.org/debian/
+alternc_debian_backport_branch: buster-backports main contrib
+
 # Custom debian sid repo for phpmyadmin when we install AlternC in buster 
-alternc_debian_sid_repo: http://ftp.debian.org/debian/
+alternc_debian_sid_repo: '{{ alternc_debian_backport_repo }}'
 alternc_debian_sid_branch: sid main
 
 ...

--- a/defaults/main/10_mysql.yml
+++ b/defaults/main/10_mysql.yml
@@ -5,14 +5,7 @@
 ####              Mysql configuration variables                ####
 ###################################################################
 
-# Password for mysql root user
-# //!\\ This password is no longer used in debian buster. 
-# root accesses mysql without password from root linux user
-root_pass_mysql: Clave_rooT_1234
-# better to put it in a vault with
-# root_pass_mysql: "{{ vault_root_pass_mysql }}" 
-
-# To Make Mysql listen on public IP (open also the firewall) 
+# To Make Mysql listen on public IP (open also the firewall, but the minimum!) 
 alternc_open_mysql: no
 
 alternc_extra_mysql_users: []

--- a/defaults/main/20_alternc.yml
+++ b/defaults/main/20_alternc.yml
@@ -85,6 +85,9 @@ phpmyadmin_debconf_dbconfig_reinstall: false
 ## used for buster needs not yet in the repositories 
 
 ## A workaround to have our local copy of alternc that we modify (for this bug: https://github.com/AlternC/AlternC/pull/378)
-alternc_replace_alternc_install: no
+alternc_replace_alternc_install: yes
 
+## A workaround to fix opendkim template, see: https://github.com/AlternC/AlternC/issues/404
+# alternc_fix_opendkim_template: yes
+  
 ...

--- a/defaults/main/30_alternc-panel.yml
+++ b/defaults/main/30_alternc-panel.yml
@@ -5,7 +5,7 @@
 ####              alternc panel configuration                  ####
 ###################################################################
 
-# MySql query options / Opciones de consulta MySql.
+# MySql query options / Opciones de consulta MySql. Move this variable to defaults/10_mysql.yml?
 alternc_query_options: " --defaults-file=/etc/alternc/my.cnf --skip-column-names alternc -B -e "
 
 # AlternC panel default administrador

--- a/defaults/main/40_alternc-plugins.yml
+++ b/defaults/main/40_alternc-plugins.yml
@@ -23,6 +23,7 @@ alternc_mailman_debconf_patch_mailman: true
 # Instalación de awstats y alternc-awstats (a 'yes' para ser compatibles con versiones anteriores del role)
 alternc_awstats_install: yes
 
+
 # Instalación de roundcube y alternc-reoundcube
 alternc_roundcube_install: no
 

--- a/defaults/main/60_alternc-slavdns.yml
+++ b/defaults/main/60_alternc-slavdns.yml
@@ -12,7 +12,7 @@
 # DNS slave bind IPs configuration by this role is not idempotent, so when you
 # want to configure or change them set the following flag to `yes`, run your playbook calling 
 # the role, and then set it again to `no`. If you let yes, the role will re-build bind config
-# each tome you run it, changing files' modification dates, even in no change done. 
+# each time you run it, changing files' modification timestamp, even in no change done. 
 alternc_slavedns_bind_ips_configure: no
 
 alternc_slavedns_bind_ips: []

--- a/defaults/main/60_alternc-slavdns.yml
+++ b/defaults/main/60_alternc-slavdns.yml
@@ -9,6 +9,12 @@
 # These variables are set through the AlternC web interface: 
 #   Administrator panel -> Manage slave DNS
 
+# DNS slave bind IPs configuration by this role is not idempotent, so when you
+# want to configure or change them set the following flag to `yes`, run your playbook calling 
+# the role, and then set it again to `no`. If you let yes, the role will re-build bind config
+# each tome you run it, changing files' modification dates, even in no change done. 
+alternc_slavedns_bind_ips_configure: no
+
 alternc_slavedns_bind_ips: []
 # - ip: 111.222.123.234
 #   mask: 32

--- a/files/alternc.install-PR474
+++ b/files/alternc.install-PR474
@@ -53,7 +53,7 @@ for i in $*; do
         -h|--help)
 	    usage; shift;;
         -v|--version)
-	    echo "AlternC - hosting software control panel, version 3.5.0~rc1+0~20191218224408.56~1.gbpc68e97"
+	    echo "AlternC - hosting software control panel, version @@REPLACED_DURING_BUILD@@"
 	    exit 2;;
         -n|--no-fixperms)
 	    export nofixperms=1; shift;;
@@ -262,14 +262,6 @@ PHPMYADMIN_BLOWFISH="$(generate_string 32)"
 # XXX: I assume this is secure if /tmp is sticky (+t)
 # we should have a better way to deal with templating, of course.
 SED_SCRIPT="/tmp/alternc.install.sedscript"
-# Escape passwords for sed and restore afterwards
-# Escaping '&' and '|' since those are used as special characters
-MYSQL_PASS_ORIG="$MYSQL_PASS"
-MYSQL_PASS=$(echo "$MYSQL_PASS" | sed -e 's/[|&]/\\&/g')
-MYSQL_MAIL_PASS_ORIG="$MYSQL_MAIL_PASS"
-MYSQL_MAIL_PASS=$(echo "$MYSQL_MAIL_PASS" | sed -e 's/[|&]/\\&/g')
-PHPMYADMIN_BLOWFISH_ORIG="$PHPMYADMIN_BLOWFISH_ORIG"
-PHPMYADMIN_BLOWFISH=$(echo "$PHPMYADMIN_BLOWFISH" | sed -e 's/[|&]/\\&/g')
 cat > $SED_SCRIPT <<EOF
 s\\%%hosting%%\\$HOSTING\\;
 s\\%%fqdn%%\\$FQDN\\;
@@ -283,9 +275,9 @@ s\\%%mx%%\\$DEFAULT_MX\\;
 s\\%%dbhost%%\\$MYSQL_HOST\\;
 s\\%%dbname%%\\$MYSQL_DATABASE\\;
 s\\%%dbuser%%\\$MYSQL_USER\\;
-s|%%dbpwd%%|$MYSQL_PASS|;
+s\\%%dbpwd%%\\$MYSQL_PASS\\;
 s\\%%db_mail_user%%\\$MYSQL_MAIL_USER\\;
-s|%%db_mail_pwd%%|$MYSQL_MAIL_PASS|;
+s\\%%db_mail_pwd%%\\$MYSQL_MAIL_PASS\\;
 s\\%%warning_message%%\\$WARNING\\;
 s\\%%fqdn_lettre%%\\$FQDN_LETTER\\;
 s\\%%version%%\\$VERSION\\;
@@ -293,15 +285,12 @@ s\\%%ns2_ip%%\\$NS2_IP\\;
 s\\%%ALTERNC_HTML%%\\$ALTERNC_HTML\\;
 s\\%%ALTERNC_MAIL%%\\$ALTERNC_MAIL\\;
 s\\%%ALTERNC_LOGS%%\\$ALTERNC_LOGS\\;
-s|%%PHPMYADMIN_BLOWFISH%%|$PHPMYADMIN_BLOWFISH|;
+s\\%%PHPMYADMIN_BLOWFISH%%\\$PHPMYADMIN_BLOWFISH\\;
 EOF
-MYSQL_PASS="$MYSQL_PASS_ORIG"
-MYSQL_MAIL_PASS="$MYSQL_MAIL_PASS_ORIG"
-PHPMYADMIN_BLOWFISH="$PHPMYADMIN_BLOWFISH_ORIG"
 
-# hook
+# hook 
 test -d /usr/lib/alternc/install.d || mkdir -p /usr/lib/alternc/install.d
-run-parts --arg=templates /usr/lib/alternc/install.d
+run-parts --arg=templates /usr/lib/alternc/install.d 
 
 
 ######################################################################
@@ -349,7 +338,6 @@ rm -f $SED_SCRIPT
 
 # add php.ini directives for AlternC in any installed php version:
 php="`ls /usr/lib/apache*/*/*php*.so | sed -e 's/^.*libphp\(.*\)\.so$/\1/' | tail -1`"
-# change with something similar to: https://github.com/AlternC/AlternC/pull/378
 if ! [[ "$php" < "7" ]]
 then
     ln -fs /etc/alternc/alternc.ini /etc/php/$php/apache2/conf.d/alternc.ini || true
@@ -678,17 +666,8 @@ touch /etc/opendkim/TrustedHosts /etc/opendkim/SigningTable /etc/opendkim/KeyTab
 grep -q "^127.0.0.1\$" /etc/opendkim/TrustedHosts || echo "127.0.0.1" >>/etc/opendkim/TrustedHosts
 grep -q "^localhost\$" /etc/opendkim/TrustedHosts || echo "localhost" >>/etc/opendkim/TrustedHosts
 grep -q "^$PUBLIC_IP\$" /etc/opendkim/TrustedHosts || echo "$PUBLIC_IP" >>/etc/opendkim/TrustedHosts
-if [ "$(lsb_release -s -c)" == 'stretch' ] ; then
-    /lib/opendkim/opendkim.service.generate
-    # Without adding '-u opendkim' after the service file is generated, opendkim
-    # will run as root, which we do not want.
-    if [ "$(grep -c 'u opendkim' /etc/systemd/system/opendkim.service.d/override.conf)" == 0 ] ; then
-        sed -i -e 's/inet:8891@127.0.0.1/& -u opendkim/' /etc/systemd/system/opendkim.service.d/override.conf
-    fi
-    systemctl daemon-reload
-fi
 
-if [ "$SYSTEMD" = "1" -a "$(lsb_release -s -c)" = "stretch" ] ; then
+if [[ "$SYSTEMD" = "1" && ! "$(lsb_release -s -c)" =~ ^(jessie|wheezy)$ ]] ; then
     /lib/opendkim/opendkim.service.generate
     # Without adding '-u opendkim' after the service file is generated, opendkim
     # will run as root, which we do not want.

--- a/tasks/10_checks-repos.yml
+++ b/tasks/10_checks-repos.yml
@@ -98,18 +98,31 @@
   register: alternc_repo_add
 
 - block: 
-  - name: Define stable as preferred debian distribution
-    lineinfile: 
-      path: /etc/apt/apt.conf.d/30StableRelease
-      line: 'APT::Default-Release "stable";'
-      create: yes
-      state: present
 
-  - name: If distribution is buster, add Sid repository for phpmyadmin
+  - name: If distribution is buster and alternc_debian_backport, add backports repository for phpmyadmin
     apt_repository: 
-      repo: "deb {{ alternc_debian_sid_repo }} {{ alternc_debian_sid_branch }}"
+      repo: "deb {{ alternc_debian_backport_repo }} {{ alternc_debian_backport_branch }}"
       state: present
-    register: debian_repo_sid_add
+    register: debian_repo_backport_add
+    when: alternc_debian_backport
+
+  - block: 
+
+    - name: Define stable as preferred debian distribution
+      lineinfile: 
+        path: /etc/apt/apt.conf.d/30StableRelease
+        line: 'APT::Default-Release "stable";'
+        create: yes
+        state: present
+
+    - name: If distribution is buster and not alternc_debian_backport, add Sid repository for phpmyadmin
+      apt_repository: 
+        repo: "deb {{ alternc_debian_sid_repo }} {{ alternc_debian_sid_branch }}"
+        state: present
+      register: debian_repo_sid_add
+    
+    when: not alternc_debian_backport
+
   when: ( ansible_distribution == 'Debian') and (ansible_distribution_release == 'buster')
   
 - name: Update packages indexes
@@ -118,6 +131,7 @@
     cache_valid_time: 0
   when: > 
       alternc_repo_add is changed or 
+      ( debian_repo_backport_add is defined and debian_repo_backport_add is changed ) or 
       ( alternc_debian_repo_sid_add is defined and alternc_debian_repo_sid_add is changed )
 
 ...

--- a/tasks/30_packages.yml
+++ b/tasks/30_packages.yml
@@ -31,6 +31,15 @@
 #    cache_valid_time: 3600
 #  when: ansible_distribution_release == "buster"
 
+- name: Install or update phpmyadmin backports dist dependencies 
+  apt:
+    name: 
+    - php-twig 
+    state: latest
+    default_release: buster-backports
+    cache_valid_time: 3600
+  when: ansible_distribution_release == "buster" and alternc_debian_backport
+
 - name: Install or update phpmyadmin Sid dist dependencies 
   apt:
     name: 
@@ -45,7 +54,7 @@
     default_release: sid
     state: latest
     cache_valid_time: 3600
-  when: ansible_distribution_release == "buster"
+  when: ansible_distribution_release == "buster" and not alternc_debian_backport
 
 ### These packages are ok by dependencies in stable. 
 ## remove these comments in a future version

--- a/tasks/40_install-alternc.yml
+++ b/tasks/40_install-alternc.yml
@@ -11,18 +11,21 @@
 ## Yes we do: https://github.com/AlternC/AlternC/issues/458
   - run alternc.install 2
 
-###### is it still needed? 
-## It is yet: ->  https://github.com/AlternC/AlternC/issues/457
-## As far as alternc koumbit version 3.5.0~rc1+0~20201103184407.66~1.gbp1b3d3f, the bug persists 
-- name: Patch-- replace alternc.install with a version for debian buster (still valid???)
+###### Workaround, replacing alternc.install. Check for new alternc package releases!
+## Up to alternc koumbit version 3.5.0~rc1+0~20201103184407.66~1.gbp1b3d3f, alternc.instal was replaced
+## for buster because of a bad check of php version: https://github.com/AlternC/AlternC/issues/459
+## Fixed in PR: https://github.com/AlternC/AlternC/pull/461 and packaged in alternc_3.5.0~rc1+0~20210517184411.71~1.gbp3007b6
+## Now we have to replace alternc.instal to properly configure opendkim in buster and upper.
+## till merge and packaging of PR:  https://github.com/AlternC/AlternC/pull/474
+- name: Patch-- replace alternc.install with a fixed version for debian buster
   copy:
-    src: files/alternc.install
+    src: files/alternc.install-PR474
     dest: /usr/share/alternc/install/alternc.install
     owner: root
     group: root
     mode: 0755
     backup: yes
-  when: alternc_replace_alternc_install
+  when: alternc_replace_alternc_install | bool
 
 - block: 
   - name: Install "mailman", mailing lists managment system
@@ -83,6 +86,17 @@
 #    backup: yes
 #  when: ansible_distribution_release == "buster"
 #  tags: workaround
+
+#### 
+### Workaround of this bug: https://github.com/AlternC/AlternC/issues/404
+#- name: Fix opendkim alternc template
+#  lineinfile:
+#    path: /etc/alternc/templates/opendkim.conf
+#    line: PidFile            /run/opendkim/opendkim.pid
+#    regexp: ^PidFile
+#    backup: yes
+#    state: present
+#  when: alternc_fix_opendkim_template | bool
 
 - name: Trigger handlers to install AlternC and notify restart Apache2
   meta: flush_handlers

--- a/tasks/70_extra-tasks.yml
+++ b/tasks/70_extra-tasks.yml
@@ -32,8 +32,6 @@
       password: "{{ alternc_mysql_user.password }}"
       priv: "{{ alternc_mysql_user.priv }}"
       login_unix_socket: /run/mysqld/mysqld.sock
-      # login_user: root
-      # login_password: "{{ root_pass_mysql }}"
       state: "{{ item.state | default ('present') }}"
     loop: "{{ alternc_extra_mysql_users }}"
     loop_control:

--- a/tasks/80_alternc-slavedns.yml
+++ b/tasks/80_alternc-slavedns.yml
@@ -1,26 +1,27 @@
 ---
 # Set alternc-slavedns servers configurations in master AlternC server
 
-- name: Deleting existing AlternC slavedns allowed IPs
-  shell: mysql {{ alternc_query_options }} 'DELETE FROM slaveip'
-  when: alternc_slavedns_bind_ips_ansible_exclusive | bool
+- name: Configurig AlternC slavedns allowed IPs
+  block:
 
-- name: Configuring slave DNS authorized IPs in master server
-  shell: >
-      mysql {{ alternc_query_options }} 
-      "INSERT IGNORE INTO slaveip (ip, class) VALUES ('{{ slave_ip.ip }}', '{{ slave_ip.mask }}')"
-  loop: "{{ alternc_slavedns_bind_ips }}"
-  loop_control:
-    loop_var: slave_ip
-  register: alternc_slaveip
+  - name: Deleting existing AlternC slavedns allowed IPs
+    shell: mysql {{ alternc_query_options }} 'DELETE FROM slaveip'
+    when: alternc_slavedns_bind_ips_ansible_exclusive | bool
 
-- debug:
-    var: alternc_slaveip
-  
-- name: Force slaveip config generation
-  file:
-    dest: /run/alternc/refresh_slave
-    state: touch
+  - name: Configuring slave DNS authorized IPs in master server
+    shell: >
+        mysql {{ alternc_query_options }} 
+        "INSERT IGNORE INTO slaveip (ip, class) VALUES ('{{ slave_ip.ip }}', '{{ slave_ip.mask }}')"
+    loop: "{{ alternc_slavedns_bind_ips }}"
+    loop_control:
+      loop_var: slave_ip
+
+  - name: Force slaveip config generation
+    file:
+      dest: /run/alternc/refresh_slave
+      state: touch
+
+  when: alternc_slavedns_bind_ips_configure | bool
 
 - name: Deleting existing AlternC slavedns accounts
   shell: mysql {{ alternc_query_options }} 'DELETE FROM slaveaccount'

--- a/tasks/80_alternc-slavedns.yml
+++ b/tasks/80_alternc-slavedns.yml
@@ -12,6 +12,15 @@
   loop: "{{ alternc_slavedns_bind_ips }}"
   loop_control:
     loop_var: slave_ip
+  register: alternc_slaveip
+
+- debug:
+    var: alternc_slaveip
+  
+- name: Force slaveip config generation
+  file:
+    dest: /run/alternc/refresh_slave
+    state: touch
 
 - name: Deleting existing AlternC slavedns accounts
   shell: mysql {{ alternc_query_options }} 'DELETE FROM slaveaccount'

--- a/tasks/90_alternc-custom.yml
+++ b/tasks/90_alternc-custom.yml
@@ -18,6 +18,9 @@
 
 ## As empirically detected in https://github.com/UdelaRInterior/ansible-AlternC/issues/12
 ## AlternC needs a first admin login into panel for the AlternC variables set to be efective. 
+# The following is not enough to log into AlternC panel. We should first pick in 
+# https://{{ alternc_debconf_desktopname }}/index.php a challange to post into the form.
+# WIP in branch: https://github.com/UdelaRInterior/ansible-AlternC/tree/web_api
 - name: "Hook: admin web access to AlternC panel just installed"
   uri:
     url: '{{ alternc_desktop_protocol }}://{{ alternc_debconf_desktopname }}/login.php'

--- a/tasks/90_alternc-custom.yml
+++ b/tasks/90_alternc-custom.yml
@@ -57,6 +57,7 @@
   uri:
     url: '{{ alternc_desktop_protocol }}://{{ alternc_debconf_desktopname }}/login.php'
     method: POST
+    follow_redirects: all
     validate_certs: no
     body_format: form-urlencoded
     body: 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,6 +33,7 @@
 - import_tasks: 70_extra-tasks.yml
 
 - import_tasks: 80_alternc-slavedns.yml
+  tags: alternc_slave_dns
 
 - import_tasks: 90_alternc-custom.yml
   tags: alternc_custom

--- a/templates/root/.my.cnf.j2
+++ b/templates/root/.my.cnf.j2
@@ -1,1 +1,0 @@
-[client] user=root password={{ root_pass_mysql }}


### PR DESCRIPTION
As a PoC (proof of concept), in this first commit 31439f14e4e900983e69da5f12b0247b77c3ab8e, we try the first solution proposed in #19, touching the `/run/alternc/refresh_slave` file after setting DNS slave IP data in the database. 

I'll try the second solution to maintain a better idempotency of the role. 